### PR TITLE
Add new methods for explicit sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,34 @@ app.in.broker.use('hello/:name', (message, next) => {
 });
 ```
 
+#### app.from.broker.send(message)
+
+It will inject a message into the middleware pipeline as if it were coming from the broker. `message`
+can be either an object containing `topic` and `payload` or a HermesMessage instance.
+
+```js
+app.from.broker.send({
+  topic: 'hello/fran',
+  payload: {
+    greetings: 'Greetings from the broker'
+  }
+});
+```
+
+#### app.from.client.send(message)
+
+It will inject a message into the middleware pipeline as if it were coming from the client. `message`
+can be either an object containing `topic` and `payload` or a HermesMessage instance.
+
+```js
+app.from.client.send({
+  topic: 'hello/fran',
+  payload: {
+    greetings: 'Greetings from the client'
+  }
+});
+```
+
 #### app.listen()
 
 Actually starts the application and listens for messages:

--- a/lib/hermes.js
+++ b/lib/hermes.js
@@ -6,18 +6,22 @@ const merge = require('utils-merge');
 const pathToRegexp = require('path-to-regexp');
 const flatten = require('array-flatten');
 const router = require('hermesjs-router');
+const HermesMessage = require('hermesjs-message');
 
 module.exports = Hermes;
 
-const proto = {};
+const proto = {
+  in: { client: {}, broker: {} },
+  from: { client: {}, broker: {} }
+};
 
 function Hermes () {
   function app (message, next) { app.handle(message, next); }
   merge(app, proto);
   merge(app, EventEmitter.prototype);
-  app.in = { client: {}, broker: {} };
-  app.in.broker.use = proto.inBrokerUse.bind(app);
-  app.in.client.use = proto.inClientUse.bind(app);
+  app.in.broker.use = proto.in.broker.use.bind(app);
+  app.in.client.use = proto.in.client.use.bind(app);
+  sendMessage = sendMessage.bind(app);
   app.route = '*';
   app.stack = [];
   app.props = {
@@ -139,7 +143,7 @@ function _useNamespacePath (args, path) {
   return args;
 }
 
-proto.inClientUse = function inClientUse () {
+proto.in.client.use = function inClientUse () {
   const parsed_args = _parseUseArgs.apply(this, arguments);
   const path = parsed_args.path;
   const callbacks = parsed_args.callbacks;
@@ -173,7 +177,7 @@ function _inClientUse (path, callbacks) {
   }
 }
 
-proto.inBrokerUse = function inBrokerUse () {
+proto.in.broker.use = function inBrokerUse () {
   const parsed_args = _parseUseArgs.apply(this, arguments);
   const path = parsed_args.path;
   const callbacks = parsed_args.callbacks;
@@ -438,4 +442,34 @@ function matchRoute (path, route) {
   keys.map((key, i) => params[key.name] = result[i+1]);
 
   return { matches: true, params, part: result[0] };
+}
+
+/**
+ * Introduces a message into the pipeline as if coming from a client adapter.
+ *
+ * @param {HermesMessage|Object} message
+ * @param {String} message.topic Message topic
+ * @param {Any} message.payload Message payload
+ */
+proto.from.client.send = function (message) {
+  sendMessage('client', message);
+};
+
+/**
+ * Introduces a message into the pipeline as if coming from a broker adapter.
+ *
+ * @param {HermesMessage|Object} message
+ * @param {String} message.topic Message topic
+ * @param {Any} message.payload Message payload
+ */
+proto.from.broker.send = function (message) {
+  sendMessage('broker', message);
+};
+
+function sendMessage (from, message) {
+  if (typeof message !== 'object') throw new Error(`hermes#from.${from}.send: message must be either an object or a HermesMessage.`);
+  if (typeof message.topic !== 'string') throw new Error(`hermes#from.${from}.send: message.topic must be a string.`);
+  if (message.payload === undefined || message.payload === null) throw new Error(`hermes#from.${from}.send: message.payload is required can not be null.`);
+
+  this.emit(`${from}:message`, message instanceof HermesMessage ? message : new HermesMessage(message));
 }


### PR DESCRIPTION
Added:
```js
hermes.from.broker.send(message)
```
It will inject a message into hermes pipeline as if it were coming from a broker.

```js
hermes.from.client.send(message)
```
It will inject a message into hermes pipeline as if it were coming from a client.
