### PR TITLE
Adds hermes.from.broker.use and hermes.from.client.use

### DIFF
--- a/lib/hermes.js
+++ b/lib/hermes.js
@@ -21,6 +21,8 @@ function Hermes () {
   merge(app, EventEmitter.prototype);
   app.in.broker.use = proto.in.broker.use.bind(app);
   app.in.client.use = proto.in.client.use.bind(app);
+  app.from.broker.use = proto.in.broker.use.bind(app);
+  app.from.client.use = proto.in.client.use.bind(app);
   sendMessage = sendMessage.bind(app);
   app.route = '*';
   app.stack = [];


### PR DESCRIPTION
This is just syntax sugar. They are the same as `hermes.in.broker.use` and `hermes.in.client.use`.